### PR TITLE
Best to make xorg-{kb,x}proto runtime deps as well

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   features:
     - vc9  # [win and py27]
@@ -44,7 +44,9 @@ requirements:
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]
     - vc 14  # [win and py35]
+    - xorg-kbproto
     - xorg-libxcb
+    - xorg-xproto
 
 test:
   commands:


### PR DESCRIPTION
The pkgconfig file requires these, so anything developing against libx11 will need them to be installed. Things don't need them for runtime, but conda doesn't (yet) distinguish between plain and "-devel" packages so we have to make a choice,