### PR TITLE
Use always_include_files to make sure we package all headers on OSX

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,12 +14,26 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]
     - vc14  # [win and py35]
+  always_include_files:
+    # Workaround for dummy X11 headers in OSX `tk` package; note that these are regexes:
+    - include/X11/cursorfont\.h
+    - include/X11/ImUtil\.h
+    - include/X11/Xcms\.h
+    - include/X11/XKBlib\.h
+    - include/X11/XlibConf\.h
+    - include/X11/Xlib\.h
+    - include/X11/Xlibint\.h
+    - include/X11/Xlib-xcb\.h
+    - include/X11/Xlocale\.h
+    - include/X11/Xregion\.h
+    - include/X11/Xresource\.h
+    - include/X11/Xutil\.h
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,19 +21,19 @@ build:
     - vc10  # [win and py34]
     - vc14  # [win and py35]
   always_include_files:
-    # Workaround for dummy X11 headers in OSX `tk` package; note that these are regexes:
-    - include/X11/cursorfont\.h
-    - include/X11/ImUtil\.h
-    - include/X11/Xcms\.h
-    - include/X11/XKBlib\.h
-    - include/X11/XlibConf\.h
-    - include/X11/Xlib\.h
-    - include/X11/Xlibint\.h
-    - include/X11/Xlib-xcb\.h
-    - include/X11/Xlocale\.h
-    - include/X11/Xregion\.h
-    - include/X11/Xresource\.h
-    - include/X11/Xutil\.h
+    # Workaround for dummy X11 headers in OSX `tk` package
+    - include/X11/cursorfont.h
+    - include/X11/ImUtil.h
+    - include/X11/Xcms.h
+    - include/X11/XKBlib.h
+    - include/X11/XlibConf.h
+    - include/X11/Xlib.h
+    - include/X11/Xlibint.h
+    - include/X11/Xlib-xcb.h
+    - include/X11/Xlocale.h
+    - include/X11/Xregion.h
+    - include/X11/Xresource.h
+    - include/X11/Xutil.h
 
 requirements:
   build:


### PR DESCRIPTION
The current OSX `tk` package includes some dummy X11 headers. This package has
`python` as a build-time dependency, which in turn requires `tk`, so
`conda-build` doesn't notice that we provide our own (real) versions of some
of the needed files, and leaves them out of the final package. The
`always_include_files` directive provides a way to work around that sort of
problem. It is *not* a good long-term solution since any package that requires
both `tk` and `xorg-libx11` as a build-time dep won't know which versions of
the header's it'll get; and lots of things have `tk` pulled in as a build-time
dependency by `python`.