### PR TITLE
Try to fix the Windows package.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,5 +28,12 @@ fi
 make -j$CPU_COUNT
 make install
 make check
-rm -rf $PREFIX/share/doc/${PKG_NAME#xorg-}
-rm -f $PREFIX/lib/libX11.a $PREFIX/lib/libX11.la
+
+rm -rf $PREFIX/share/doc/libX11 $PREFIX/share/man
+
+# Prefer dynamic libraries to static, and dump libtool helper files
+for lib_ident in X11 X11-xcb; do
+    if [ -e $PREFIX/lib/lib${lib_ident}$SHLIB_EXT ] ; then
+        rm -f $PREFIX/lib/lib${lib_ident}.a $PREFIX/lib/lib${lib_ident}.la
+    fi
+done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   detect_binary_files_with_prefix: true
   features:
     - vc9  # [win and py27]


### PR DESCRIPTION
On Windows we don't make shared libraries so we were deleting the key library file at the bottom of build.sh! Also we weren't treating libX11-xcb on the same footing as libX11. And we were distributing a bunch of manpage that I suspect nobody wants. Let's try to tidy that all up.