### PR TITLE
Unconditionally remove libtool helper files.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -33,7 +33,8 @@ rm -rf $PREFIX/share/doc/libX11 $PREFIX/share/man
 
 # Prefer dynamic libraries to static, and dump libtool helper files
 for lib_ident in X11 X11-xcb; do
+    rm -f $PREFIX/lib/lib${lib_ident}.la
     if [ -e $PREFIX/lib/lib${lib_ident}$SHLIB_EXT ] ; then
-        rm -f $PREFIX/lib/lib${lib_ident}.a $PREFIX/lib/lib${lib_ident}.la
+        rm -f $PREFIX/lib/lib${lib_ident}.a
     fi
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: true
   features:
     - vc9  # [win and py27]


### PR DESCRIPTION
I tried to be nice but if the files exist at all, they cause problems on Windows.