### PR TITLE
Remove Libtool `.la` files from Windows packages [skip travis] [skip circle]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,10 +9,7 @@ environment:
     secure: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
 
   matrix:
-    - CONFIG: win_c_compilervs2008
-      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
-
-    - CONFIG: win_c_compilervs2015
+    - CONFIG: win_
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -1,4 +1,2 @@
-c_compiler:
-- vs2008
 m2w64_c_compiler:
 - m2w64-toolchain

--- a/.ci_support/win_c_compilervs2015.yaml
+++ b/.ci_support/win_c_compilervs2015.yaml
@@ -1,4 +1,0 @@
-c_compiler:
-- vs2015
-m2w64_c_compiler:
-- m2w64-toolchain

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   always_include_files:
     # Workaround for dummy X11 headers in OSX `tk` package
@@ -64,8 +64,6 @@ test:
     - test -f $PREFIX/lib/lib{{ lib_ident }}.dylib  # [osx]
     - test -f $PREFIX/lib/lib{{ lib_ident }}.so  # [linux]
     - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.dll.a exit /b 1  # [win]
-    - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.a exit /b 1  # [win]
-    - if not exist %PREFIX%/Library/lib/lib{{ lib_ident }}.la exit /b 1  # [win]
     - if not exist %PREFIX%/Library/bin/msys-{{ lib_ident }}-*.dll exit /b 1  # [win]
     {% endfor %}
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]


### PR DESCRIPTION
Going through and removing the Libtool `.la` files from the X.org Windows packages, in line with the new policy ([discussion](https://github.com/conda-forge/staged-recipes/issues/673)).

* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.